### PR TITLE
Add Lato font alias for Tailwind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,6 +8,7 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Lato', 'sans-serif'],
+        lato: ['Lato', 'sans-serif'],
         raleway: ['Raleway', 'sans-serif'],
       },
 


### PR DESCRIPTION
## Summary
- add `lato` alias in Tailwind config
- add `.gitignore` to avoid committing node_modules

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68744cf8bb78832f849e4924a0beb6e8