### PR TITLE
Fix Tailwind config syntax

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
   content: [
     "./index.html",
     "./src/**/*.{js,jsx}",


### PR DESCRIPTION
## Summary
- use CommonJS syntax in `tailwind.config.js`

## Testing
- `npm run build` *(fails: `vite: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68744dbd1af8832f8d2335a2bb1ee82e